### PR TITLE
rewrite newton implementation

### DIFF
--- a/derivee/python/newton_cours.py
+++ b/derivee/python/newton_cours.py
@@ -1,106 +1,101 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
+import math
+
 #------------------------------------------
 # Newton
 #------------------------------------------
+
+
+def newton_iter(x0, func, derivee, n, cible=None):
+    """
+    Méthode de newton algorithme iteratif
+
+    :param x0: terme initial
+    :param func: function à etudier
+    :param derivee: fonction derivee de func
+    :param n: nombre d'iterations
+    :param cible: la valeur que l'on recherche (sert uniquement a calculer l'erreur)
+    :return: valuer qui approche la solution
+    """
+    x = x0
+    for i in range(n):
+        x = x - func(x)/derivee(x)
+        if cible is not None:
+            print(f"Etape {i} : {x} Erreur : {x - cible}")
+    return x
+
+
+def newton_rec(x0, func, derivee, n, cible=None):
+    """
+    Méthode de newton algorithme recursive
+
+    :param x0: terme initial
+    :param func: function à etudier
+    :param derivee: fonction derivee de func
+    :param n: nombre d'iterations
+    :param cible: la valeur que l'on recherche (sert uniquement a calculer l'erreur)
+    :return: valuer qui approche la solution
+    """
+    n = n - 1
+    x = x0
+    x = x - func(x)/derivee(x)
+    if cible is not None:
+        print(f"Etape {n} : {x} Erreur : {x - cible}")
+    if n == 0:
+        return x
+    else:
+        return newton_rec(x, func, derivee, n, cible=cible)
+
+
+###########################
+# Applications 
+###########################
+print("Calcul de racine cubique de 100 par la méthode de Newton")
+
 
 # La fonction f(x)
-def f(x):
+def h(x):
     return x**3 - 100
 
-# La fonction dérivée f'(x)
-def df(x):
-    return 3*(x**2)    
-
-
-# Méthode de Newton 
-# x0 est le terme initial, n est le nombre d'étapes
-def newton(x0,n):  
-    x = x0
-    for i in range(1,n+1):
-        x = x - f(x)/df(x)
-        # print("Etape ", i, " : ",x,"Erreur :",x-100**(1/3)) 
-        # print("Etape ", i, " : ",x,"Erreur :",x-100**(1/3))
-    return x
-
-
-    
-print("Calcul de racine cubique de 100 par la méthode de Newton")
-print(newton(10,9))  
-
-#------------------------------------------
-# Newton
-#------------------------------------------
-
-
-# Calcul de racine cubique de 100 avec 1000 décimales
-
-# Module décimale pour avoir une grande précision 
-from decimal import *
-
-# Precision souhaitée (par exemple 1010 décimales pour éviter les erreurs d'arrondi)
-getcontext().prec = 1010
-
-
-# Cas de la racine carrée sqrt(a)
-# n est le nombre d'itérations
-def newton_bis(x0,n):  
-    x = Decimal(x0)
-    for i in range(1,n+1):
-        x = x - f(x)/df(x)
-        # print("Etape ", i, " : ", x) 
-        # print("Etape ", i, " : ",x,"Erreur :",x**3-100)
-    return x
-
-
-# Exemple 
-n=13
-sqrt3_100 = newton_bis(10,n)
-# print("Racine cubique de 100 (n=%d) : " %n, sqrt3_100)
-
-# Test
-# print(sqrt3_100-Decimal(100**1/3))
-# print(sqrt3_100)
-print(sqrt3_100**3)
-
-
-
-#------------------------------------------
-# Newton
-#------------------------------------------
-
-from math import *
-
-# La fonction g(x)
-def g(x):
-    return x**2 - sin(x) + 1 
-
-# La fonction f(x) ( = g'(x) )
-def f(x):
-    return 2*x - cos(x) 
 
 # La fonction dérivée f'(x)
-def df(x):
-    return 2 + sin(x)
+def h_prime(x):
+    return 3*(x**2)
 
-ell = 0.45018361129487355
 
-def newton(x0,n):  
-    x = x0
-    for i in range(1,n+1):
-        x = x - f(x)/df(x)
-        print("Etape ", i, " : ",x,"Erreur :",x-ell)
-    return x
+print("implementation iterative", newton_iter(10, h, h_prime, 9))
+print("implementation recursive", newton_rec(10, h, h_prime, 9))
+
 
 print("Calcul de 'l' où g atteint son minimum (là ou f=0) par la méthode de Newton")
 
-print("-- x0 = 0 --")
-ell = newton(0,10)
-ell = 0.45018361129487355
-print('l =',ell)
-print('f(l) =',f(ell)) 
-print('g(l) =',g(ell)) 
+# La fonction g(x)
+def g(x):
+    return x ** 2 - math.sin(x) + 1
 
+# La fonction f(x) ( = g'(x) )
+def f(x):
+    return 2 * x - math.cos(x)
+
+# La fonction dérivée f'(x)
+def f_prime(x):
+    return 2 + math.sin(x)
+
+ell = 0.45018361129487355
+
+
+ell = 0.45018361129487355
+print("\nCalcul avec x0 = 0 et 10 iterations")
+print("-- x0 = 0 --")
+print(newton_iter(0, f, f_prime, 10, cible=ell))
+
+print("-------------------------------")
+print('l =', ell)
+print('f(l) =', f(ell))
+print('g(l) =', g(ell))
+
+print("\nCalcul avec x0 = 10 et 10 iterations")
 print("-- x0 = 10 --")
-ell = newton(10,10)
+print(newton_rec(10, f, f_prime, 10, cible=ell))


### PR DESCRIPTION
l'implementation proposée pour la méthode de newton utilise des variables globales.
ca fonctione mais c'est une tres mauvaise habitude.
meme si c'est un cours de math cela n'empeche pas de prendre de bons reflexes ;-)

de plus je propose 2  implementations: iterative, comme dans le code opriginal
et recursive pour coller au cours.

cela permet de bien voir que l'a methode est generale et s'applique a toute les fonctions.
pas la peine de recoder newton pour chaque fonction comme pouvait le laisser faire penser la version precedente

par contre je n'ai pas reimplementer une version avec une plus grande precision

